### PR TITLE
Change the batch model suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,22 @@ The reasons why we use Valkey instead of Redis are:
 Batch processing is a cost-optimization feature that uses OpenAI's batch API to reduce costs. Here's how it works:
 
 ### How It Works
-1. When you send a request with a `-batch` suffix (e.g., `gpt-4o-batch`):
+1. Add a batch model to the config (e.g., `gpt-4o@batch`).
+
+```yaml
+models:
+  - name: "gpt-4o@batch"
+    rate_key: "gpt-4o@batch"
+    rpm: 10_000
+    tpm: 30_000_000
+```
+
+2. When you send a request with a `@batch` suffix (e.g., `gpt-4o@batch`):
    - Your request joins a batch queue
    - Batches are processed every 10 seconds or when 50,000 requests accumulate
    - The request waits for the batch to complete
 
-2. Response Behavior:
+3. Response Behavior:
    - The request blocks until the batch is completed
    - If the batch completes within your request timeout: You get results
    - If timeout occurs: You can retry with the same request
@@ -176,7 +186,7 @@ Batch processing is a cost-optimization feature that uses OpenAI's batch API to 
 ### Usage Example
 ```json
 {
-  "model": "gpt-4o-batch",
+  "model": "gpt-4o@batch",
   "messages": [
     [{"role": "user", "content": "Hello! How can you help me today?"}]
   ]
@@ -267,10 +277,10 @@ Specify multiple models for automatic fallback:
 
 ### Batch Processing
 
-Add `-batch` suffix for batch processing:
+Add `@batch` suffix for batch processing:
 ```json
 {
-  "model": "gpt-4-batch"
+  "model": "gpt-4@batch"
 }
 ```
 Currently, batch processing is only supported for OpenAI models.

--- a/config.yaml
+++ b/config.yaml
@@ -65,64 +65,64 @@ providers:
             rate_key: "gpt-3.5-turbo"
             rpm: 10_000
             tpm: 50_000_000
-          - name: "gpt-4o-batch"
-            rate_key: "gpt-4o-batch"
+          - name: "gpt-4o@batch"
+            rate_key: "gpt-4o@batch"
             rpm: 1_000_000
             tpm: 10_000_000_000
-          - name: "gpt-4o-2024-05-13-batch"
-            rate_key: "gpt-4o-batch"
+          - name: "gpt-4o-2024-05-13@batch"
+            rate_key: "gpt-4o@batch"
             rpm: 1_000_000
             tpm: 10_000_000_000
-          - name: "gpt-4o-2024-08-06-batch"
-            rate_key: "gpt-4o-batch"
+          - name: "gpt-4o-2024-08-06@batch"
+            rate_key: "gpt-4o@batch"
             rpm: 1_000_000
             tpm: 10_000_000_000
-          - name: "gpt-4o-mini-batch"
-            rate_key: "gpt-4o-mini-batch"
+          - name: "gpt-4o-mini@batch"
+            rate_key: "gpt-4o-mini@batch"
             rpm: 1_000_000
             tpm: 15_000_000_000
-          - name: "gpt-4o-mini-2024-07-18-batch"
-            rate_key: "gpt-4o-mini-batch"
+          - name: "gpt-4o-mini-2024-07-18@batch"
+            rate_key: "gpt-4o-mini@batch"
             rpm: 1_000_000
             tpm: 15_000_000_000
-          - name: "gpt-4-turbo-batch"
-            rate_key: "gpt-4-turbo-batch"
+          - name: "gpt-4-turbo@batch"
+            rate_key: "gpt-4-turbo@batch"
             rpm: 1_000_000
             tpm: 300_000_000
-          - name: "gpt-4-turbo-2024-04-09-batch"
-            rate_key: "gpt-4-turbo-batch"
+          - name: "gpt-4-turbo-2024-04-09@batch"
+            rate_key: "gpt-4-turbo@batch"
             rpm: 1_000_000
             tpm: 300_000_000
-          - name: "gpt-4-turbo-preview-batch"
-            rate_key: "gpt-4-turbo-batch"
+          - name: "gpt-4-turbo-preview@batch"
+            rate_key: "gpt-4-turbo@batch"
             rpm: 1_000_000
             tpm: 300_000_000
-          - name: "gpt-4-0125-preview-batch"
-            rate_key: "gpt-4-batch"
+          - name: "gpt-4-0125-preview@batch"
+            rate_key: "gpt-4@batch"
             rpm: 1_000_000
             tpm: 150_000_000
-          - name: "gpt-4-1106-preview-batch"
-            rate_key: "gpt-4-batch"
+          - name: "gpt-4-1106-preview@batch"
+            rate_key: "gpt-4@batch"
             rpm: 1_000_000
             tpm: 150_000_000
-          - name: "gpt-4-batch"
-            rate_key: "gpt-4-batch"
+          - name: "gpt-4@batch"
+            rate_key: "gpt-4@batch"
             rpm: 1_000_000
             tpm: 150_000_000
-          - name: "gpt-4-0613-batch"
-            rate_key: "gpt-4-batch"
+          - name: "gpt-4-0613@batch"
+            rate_key: "gpt-4@batch"
             rpm: 1_000_000
             tpm: 150_000_000
-          - name: "gpt-3.5-turbo-batch"
-            rate_key: "gpt-3.5-turbo-batch"
+          - name: "gpt-3.5-turbo@batch"
+            rate_key: "gpt-3.5-turbo@batch"
             rpm: 1_000_000
             tpm: 5_000_000_000
-          - name: "gpt-3.5-turbo-0126-batch"
-            rate_key: "gpt-3.5-turbo-batch"
+          - name: "gpt-3.5-turbo-0126@batch"
+            rate_key: "gpt-3.5-turbo@batch"
             rpm: 1_000_000
             tpm: 5_000_000_000
-          - name: "gpt-3.5-turbo-1106-batch"
-            rate_key: "gpt-3.5-turbo-batch"
+          - name: "gpt-3.5-turbo-1106@batch"
+            rate_key: "gpt-3.5-turbo@batch"
             rpm: 1_000_000
             tpm: 5_000_000_000
   vertex:

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -73,7 +73,7 @@ func NewEndpoint(apiKey string) *Endpoint {
 }
 
 func (p *Endpoint) GenerateChatCompletion(ctx context.Context, openaiRequest *openai.ChatCompletionRequest) (*openai.ChatCompletionResponse, error) {
-	if batchModel, found := strings.CutSuffix(openaiRequest.Model, "-batch"); found {
+	if batchModel, found := strings.CutSuffix(openaiRequest.Model, "@batch"); found {
 		openaiRequest.Model = batchModel
 		return p.GenerateBatchChatCompletion(ctx, openaiRequest)
 	}


### PR DESCRIPTION
`-batch` suffix can be introduced in the future as a real model name since a dash `-` is often used in a model name. Changed it to `@batch` and updated the README.md to explain how to add a batch model to the config file.