### PR TITLE
Support custom OpenAI endpoints

### DIFF
--- a/ogem.go
+++ b/ogem.go
@@ -9,6 +9,15 @@ import (
 type ProvidersStatus map[string]*ProviderStatus
 
 type ProviderStatus struct {
+	// Endpoint to use for generating completions. E.g., "localhost:8080"
+	Endpoint string `yaml:"endpoint" json:"endpoint"`
+
+	// Protocol to use for generating completions. E.g., "openai"
+	Protocol string `yaml:"protocol" json:"protocol"`
+
+	// Environment variable name for the API key. E.g., "SELF_HOST_API_KEY"
+	ApiKeyEnv string `yaml:"api_key_env" json:"api_key_env"`
+
 	// Regions maps region names to their status.
 	// The "default" region configures provider-wide settings.
 	// E.g., Regions["us-central1"]

--- a/ogem.go
+++ b/ogem.go
@@ -9,10 +9,10 @@ import (
 type ProvidersStatus map[string]*ProviderStatus
 
 type ProviderStatus struct {
-	// Endpoint to use for generating completions. E.g., "localhost:8080"
-	Endpoint string `yaml:"endpoint" json:"endpoint"`
+	// Base URL of the endpoint. E.g., "http://localhost:8080/v1"
+	BaseUrl string `yaml:"base_url" json:"base_url"`
 
-	// Protocol to use for generating completions. E.g., "openai"
+	// API protocol used by the endpoint. E.g., "openai"
 	Protocol string `yaml:"protocol" json:"protocol"`
 
 	// Environment variable name for the API key. E.g., "SELF_HOST_API_KEY"

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -50,18 +51,28 @@ type BatchJob struct {
 }
 
 type Endpoint struct {
-	apiKey        string
-	client        *http.Client
-	batchJobs     map[string]*BatchJob
-	batchJobMutex sync.RWMutex
+	apiKey       string
+	endpoint     *url.URL
+	client       *http.Client
+	providerName string
+	region       string
 
+	batchJobs       map[string]*BatchJob
+	batchJobMutex   sync.RWMutex
 	batchChan       chan *BatchJob
 	stopBatchSignal chan struct{}
 }
 
-func NewEndpoint(apiKey string) *Endpoint {
+func NewEndpoint(providerName string, region string, address string, apiKey string) (*Endpoint, error) {
+	parsedAddress, err := url.Parse(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid endpoint: %v", err)
+	}
 	endpoint := &Endpoint{
+		providerName:    providerName,
+		region:          region,
 		apiKey:          apiKey,
+		endpoint:        parsedAddress,
 		client:          &http.Client{Timeout: 30 * time.Minute},
 		batchJobs:       make(map[string]*BatchJob),
 		batchChan:       make(chan *BatchJob),
@@ -69,7 +80,7 @@ func NewEndpoint(apiKey string) *Endpoint {
 	}
 
 	go endpoint.batchManager()
-	return endpoint
+	return endpoint, nil
 }
 
 func (p *Endpoint) GenerateChatCompletion(ctx context.Context, openaiRequest *openai.ChatCompletionRequest) (*openai.ChatCompletionResponse, error) {
@@ -83,7 +94,12 @@ func (p *Endpoint) GenerateChatCompletion(ctx context.Context, openaiRequest *op
 		return nil, fmt.Errorf("failed to marshal request: %v", err)
 	}
 
-	httpRequest, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/chat/completions", strings.NewReader(string(jsonData)))
+	endpointPath, err := url.JoinPath(p.endpoint.String(), "chat/completions")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build endpoint path: %v", err)
+	}
+
+	httpRequest, err := http.NewRequestWithContext(ctx, "POST", endpointPath, strings.NewReader(string(jsonData)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
@@ -519,11 +535,11 @@ func (p *Endpoint) handleBatchError(batch []*BatchJob, err error) {
 }
 
 func (p *Endpoint) Provider() string {
-	return "openai"
+	return p.providerName
 }
 
 func (p *Endpoint) Region() string {
-	return REGION
+	return p.region
 }
 
 func (p *Endpoint) Ping(ctx context.Context) (time.Duration, error) {

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -52,7 +52,7 @@ type BatchJob struct {
 
 type Endpoint struct {
 	apiKey       string
-	endpoint     *url.URL
+	baseUrl      *url.URL
 	client       *http.Client
 	providerName string
 	region       string
@@ -63,8 +63,8 @@ type Endpoint struct {
 	stopBatchSignal chan struct{}
 }
 
-func NewEndpoint(providerName string, region string, address string, apiKey string) (*Endpoint, error) {
-	parsedAddress, err := url.Parse(address)
+func NewEndpoint(providerName string, region string, baseUrl string, apiKey string) (*Endpoint, error) {
+	parsedBaseUrl, err := url.Parse(baseUrl)
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint: %v", err)
 	}
@@ -72,7 +72,7 @@ func NewEndpoint(providerName string, region string, address string, apiKey stri
 		providerName:    providerName,
 		region:          region,
 		apiKey:          apiKey,
-		endpoint:        parsedAddress,
+		baseUrl:         parsedBaseUrl,
 		client:          &http.Client{Timeout: 30 * time.Minute},
 		batchJobs:       make(map[string]*BatchJob),
 		batchChan:       make(chan *BatchJob),
@@ -94,7 +94,7 @@ func (p *Endpoint) GenerateChatCompletion(ctx context.Context, openaiRequest *op
 		return nil, fmt.Errorf("failed to marshal request: %v", err)
 	}
 
-	endpointPath, err := url.JoinPath(p.endpoint.String(), "chat/completions")
+	endpointPath, err := url.JoinPath(p.baseUrl.String(), "chat/completions")
 	if err != nil {
 		return nil, fmt.Errorf("failed to build endpoint path: %v", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -138,13 +138,13 @@ func newEndpoint(provider string, region string, config *Config) (provider.AiEnd
 	}
 }
 
-func newCustomEndpoint(providerName string, protocol string, endpoint string, apiKeyEnv string, region string) (provider.AiEndpoint, error) {
+func newCustomEndpoint(providerName string, protocol string, baseUrl string, apiKeyEnv string, region string) (provider.AiEndpoint, error) {
 	switch protocol {
 	case "openai":
 		if region != providerName {
 			return nil, fmt.Errorf("region is not supported for custom openai provider; region field must match provider name")
 		}
-		return openaiProvider.NewEndpoint(providerName, region, endpoint, env.RequiredStringVariable(apiKeyEnv))
+		return openaiProvider.NewEndpoint(providerName, region, baseUrl, env.RequiredStringVariable(apiKeyEnv))
 	default:
 		return nil, fmt.Errorf("unsupported protocol: %s, only openai is supported", protocol)
 	}
@@ -176,13 +176,13 @@ func NewProxyServer(stateManager state.Manager, cleanup func(), config Config, l
 	) bool {
 		var endpoint provider.AiEndpoint
 		var err error
-		if providerData.Endpoint == "" {
+		if providerData.BaseUrl == "" {
 			endpoint, err = newEndpoint(providerName, region, &config)
 		} else {
 			endpoint, err = newCustomEndpoint(
 				providerName,
 				providerData.Protocol,
-				providerData.Endpoint,
+				providerData.BaseUrl,
 				providerData.ApiKeyEnv,
 				region,
 			)


### PR DESCRIPTION
```
  mine:
    endpoint: http://your-machine-address:8080/v1
    protocol: openai
    api_key_env: YOUR_INSTANCE_API_KEY
    regions:
      mine:
        models:
          - name: "mine"
            rate_key: "mine"
            rpm: 10_000
            tpm: 30_000_000
```