### PR TITLE
Downgrade the Go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yanolja/ogem
 
-go 1.23.3
+go 1.22
 
 require (
 	cloud.google.com/go/vertexai v0.13.2


### PR DESCRIPTION
It limits people's use of the library in their projects.
I will downgrade the version further if needed but at this time, 1.22.