### PR TITLE
Increase Unit Test Coverage for `utils` and `copy` Packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .gpt
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .gpt
+.idea

--- a/utils/copy/copy_test.go
+++ b/utils/copy/copy_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCopy(t *testing.T) {
+func TestDeep(t *testing.T) {
 	t.Run("Deep copied int type", func(t *testing.T) {
 		original := 42
 		copied, err := Deep(original)
@@ -52,17 +52,14 @@ func TestCopy(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotSame(t, original, copied)
 		assert.Equal(t, *original, *copied)
-
 		*copied = "new"
 		assert.NotEqual(t, *original, *copied)
 	})
 
-	t.Run("Fails copied empty values", func(t *testing.T) {
+	t.Run("Fails copying struct{}{}", func(t *testing.T) {
 		original := struct{}{}
-
 		copied, err := Deep(original)
 		assert.NoError(t, err)
 		assert.Equal(t, original, copied)
 	})
-
 }

--- a/utils/copy/copy_test.go
+++ b/utils/copy/copy_test.go
@@ -6,135 +6,62 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestStruct is a test struct for deep copy, a struct may be shallow copied by copying the pointer to the struct
-type TestStruct struct {
-	String string
-	Int    int
-	Float  float64
-	Bool   bool
-	Slice  []string
-	Map    map[string]int
-	Ptr    *string
-	Any    any
-}
-
 func TestCopy(t *testing.T) {
-
-	t.Run("Successfully deep copied primitive types", func(t *testing.T) {
-		original := TestStruct{
-			String: "test",
-			Int:    42,
-			Float:  3.14,
-			Bool:   true,
-		}
-
-		copied, err := Deep(original)
-		assert.NoError(t, err)
-		assert.Equal(t, original, copied)
-	})
-
-	t.Run("Successfully deep copy slice types", func(t *testing.T) {
-		original := TestStruct{
-			Slice: []string{"a", "b", "c"},
-		}
-
-		copied, err := Deep(original)
-		assert.NoError(t, err)
-		assert.Equal(t, original, copied)
-
-		// Modify the copied slice to verify deep copy
-		copied.Slice[0] = "x"
-		assert.NotEqual(t, original.Slice[0], "x", "Deep() created a shallow copy of slice")
-	})
-
-	t.Run("Successfully deep copy map types", func(t *testing.T) {
-		original := TestStruct{
-			Map: map[string]int{
-				"a": 1,
-				"b": 2,
-			},
-		}
-
-		copied, err := Deep(original)
-		assert.NoError(t, err)
-		assert.Equal(t, original, copied)
-
-		// Modify the copied map to verify deep copy
-		copied.Map["a"] = 3
-		assert.NotEqual(t, original.Map["a"], 3, "Deep() created a shallow copy of map")
-	})
-
-	t.Run("Successfully deep copy pointer types", func(t *testing.T) {
-		str := "test"
-		original := TestStruct{
-			Ptr: &str,
-		}
-
-		copied, err := Deep(original)
-		assert.NoError(t, err)
-		assert.Equal(t, original, copied)
-
-		// Modify the copied pointer to verify deep copy
-		*copied.Ptr = "new"
-		assert.NotEqual(t, *original.Ptr, "new", "Deep() created a shallow copy of pointer")
-	})
-
-	t.Run("Successfully copied any types", func(t *testing.T) {
-		original := TestStruct{
-			Any: map[string]any{
-				"key": "value",
-			},
-		}
-
-		copied, err := Deep(original)
-		assert.NoError(t, err)
-		assert.Equal(t, original, copied)
-
-		// Modify the copied any to verify deep copy
-		copiedMap := copied.Any.(map[string]any)
-		copiedMap["key"] = "new value"
-		assert.NotEqual(t, original.Any.(map[string]any)["key"], "new value", "Deep() created a shallow copy of any")
-	})
-
-	t.Run("Fails copied because something return nil", func(t *testing.T) {
-		original := TestStruct{
-			Slice: nil,
-			Map:   nil,
-			Ptr:   nil,
-			Any:   nil,
-		}
-
-		copied, err := Deep(original)
-		assert.NoError(t, err)
-		assert.Equal(t, original, copied)
-	})
-
-	t.Run("Fails copied empty values", func(t *testing.T) {
-		original := TestStruct{
-			Slice: []string{},
-			Map:   map[string]int{},
-			Any:   map[string]any{},
-		}
-
-		copied, err := Deep(original)
-		assert.NoError(t, err)
-		assert.Equal(t, original, copied)
-	})
-
-	t.Run("primitive type", func(t *testing.T) {
+	t.Run("Deep copied int type", func(t *testing.T) {
 		original := 42
 		copied, err := Deep(original)
 		assert.NoError(t, err)
 		assert.Equal(t, original, copied)
 	})
 
-	t.Run("slice directly", func(t *testing.T) {
-		original := []string{"a", "b", "c"}
+	t.Run("Deep copied bool type", func(t *testing.T) {
+		original := true
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+	})
+
+	t.Run("Deep copied string type", func(t *testing.T) {
+		original := "string"
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+	})
+
+	t.Run("Fails copied in case nil", func(t *testing.T) {
+		original := error(nil)
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+	})
+
+	t.Run("Deep copied any types", func(t *testing.T) {
+		original := []any{1, 'a', "test", true, 42.0, []any{1, 2, 3}, map[string]any{"key": "value"}}
+		copied, err := Deep(original)
+		copied[0] = 2
+		copied[1] = 'b'
+		copied[4] = 'c'
+		assert.NoError(t, err)
+		assert.NotEqual(t, original, copied)
+	})
+
+	t.Run("Successfully deep copy pointer types", func(t *testing.T) {
+		str := "test"
+		original := &str
 		copied, err := Deep(original)
 		assert.NoError(t, err)
 		assert.Equal(t, original, copied)
 
-		copied[0] = "x"
-		assert.NotEqual(t, original[0], "x", "Deep() created a shallow copy of slice")
+		*copied = "new"
+		assert.NotEqual(t, *original, "new")
 	})
+
+	t.Run("Fails copied empty values", func(t *testing.T) {
+		original := struct{}{}
+
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+	})
+
 }

--- a/utils/copy/copy_test.go
+++ b/utils/copy/copy_test.go
@@ -50,10 +50,11 @@ func TestCopy(t *testing.T) {
 		original := &str
 		copied, err := Deep(original)
 		assert.NoError(t, err)
-		assert.Equal(t, original, copied)
+		assert.NotSame(t, original, copied)
+		assert.Equal(t, *original, *copied)
 
 		*copied = "new"
-		assert.NotEqual(t, *original, "new")
+		assert.NotEqual(t, *original, *copied)
 	})
 
 	t.Run("Fails copied empty values", func(t *testing.T) {

--- a/utils/copy/copy_test.go
+++ b/utils/copy/copy_test.go
@@ -1,0 +1,147 @@
+package copy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestStruct struct {
+	String    string
+	Int       int
+	Float     float64
+	Bool      bool
+	Slice     []string
+	Map       map[string]int
+	Ptr       *string
+	Interface interface{}
+}
+
+func TestCopy(t *testing.T) {
+	// Test case 1: Copy primitive types
+	t.Run("primitive types", func(t *testing.T) {
+		original := TestStruct{
+			String: "test",
+			Int:    42,
+			Float:  3.14,
+			Bool:   true,
+		}
+
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+	})
+
+	// Test case 2: Copy slice
+	t.Run("slice", func(t *testing.T) {
+		original := TestStruct{
+			Slice: []string{"a", "b", "c"},
+		}
+
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+
+		// Modify the copied slice to verify deep copy
+		copied.Slice[0] = "x"
+		assert.NotEqual(t, original.Slice[0], "x", "Deep() created a shallow copy of slice")
+	})
+
+	// Test case 3: Copy map
+	t.Run("map", func(t *testing.T) {
+		original := TestStruct{
+			Map: map[string]int{
+				"a": 1,
+				"b": 2,
+			},
+		}
+
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+
+		// Modify the copied map to verify deep copy
+		copied.Map["a"] = 3
+		assert.NotEqual(t, original.Map["a"], 3, "Deep() created a shallow copy of map")
+	})
+
+	// Test case 4: Copy pointer
+	t.Run("pointer", func(t *testing.T) {
+		str := "test"
+		original := TestStruct{
+			Ptr: &str,
+		}
+
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+
+		// Modify the copied pointer to verify deep copy
+		*copied.Ptr = "new"
+		assert.NotEqual(t, *original.Ptr, "new", "Deep() created a shallow copy of pointer")
+	})
+
+	// Test case 5: Copy interface
+	t.Run("interface", func(t *testing.T) {
+		original := TestStruct{
+			Interface: map[string]interface{}{
+				"key": "value",
+			},
+		}
+
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+
+		// Modify the copied interface to verify deep copy
+		copiedMap := copied.Interface.(map[string]interface{})
+		copiedMap["key"] = "new value"
+		assert.NotEqual(t, original.Interface.(map[string]interface{})["key"], "new value", "Deep() created a shallow copy of interface")
+	})
+
+	// Test case 6: Copy nil values
+	t.Run("nil values", func(t *testing.T) {
+		original := TestStruct{
+			Slice:     nil,
+			Map:       nil,
+			Ptr:       nil,
+			Interface: nil,
+		}
+
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+	})
+
+	// Test case 7: Copy empty values
+	t.Run("empty values", func(t *testing.T) {
+		original := TestStruct{
+			Slice:     []string{},
+			Map:       map[string]int{},
+			Interface: map[string]interface{}{},
+		}
+
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+	})
+
+	// Test case 8: Copy primitive type directly
+	t.Run("primitive type", func(t *testing.T) {
+		original := 42
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+	})
+
+	// Test case 9: Copy slice directly
+	t.Run("slice directly", func(t *testing.T) {
+		original := []string{"a", "b", "c"}
+		copied, err := Deep(original)
+		assert.NoError(t, err)
+		assert.Equal(t, original, copied)
+
+		copied[0] = "x"
+		assert.NotEqual(t, original[0], "x", "Deep() created a shallow copy of slice")
+	})
+}

--- a/utils/copy/copy_test.go
+++ b/utils/copy/copy_test.go
@@ -6,19 +6,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestStruct is a test struct for deep copy, a struct may be shallow copied by copying the pointer to the struct
 type TestStruct struct {
-	String    string
-	Int       int
-	Float     float64
-	Bool      bool
-	Slice     []string
-	Map       map[string]int
-	Ptr       *string
-	Interface interface{}
+	String string
+	Int    int
+	Float  float64
+	Bool   bool
+	Slice  []string
+	Map    map[string]int
+	Ptr    *string
+	Any    any
 }
 
 func TestCopy(t *testing.T) {
-	// Test case 1: Copy primitive types
+
 	t.Run("primitive types", func(t *testing.T) {
 		original := TestStruct{
 			String: "test",
@@ -32,7 +33,6 @@ func TestCopy(t *testing.T) {
 		assert.Equal(t, original, copied)
 	})
 
-	// Test case 2: Copy slice
 	t.Run("slice", func(t *testing.T) {
 		original := TestStruct{
 			Slice: []string{"a", "b", "c"},
@@ -47,7 +47,6 @@ func TestCopy(t *testing.T) {
 		assert.NotEqual(t, original.Slice[0], "x", "Deep() created a shallow copy of slice")
 	})
 
-	// Test case 3: Copy map
 	t.Run("map", func(t *testing.T) {
 		original := TestStruct{
 			Map: map[string]int{
@@ -65,7 +64,6 @@ func TestCopy(t *testing.T) {
 		assert.NotEqual(t, original.Map["a"], 3, "Deep() created a shallow copy of map")
 	})
 
-	// Test case 4: Copy pointer
 	t.Run("pointer", func(t *testing.T) {
 		str := "test"
 		original := TestStruct{
@@ -81,10 +79,9 @@ func TestCopy(t *testing.T) {
 		assert.NotEqual(t, *original.Ptr, "new", "Deep() created a shallow copy of pointer")
 	})
 
-	// Test case 5: Copy interface
-	t.Run("interface", func(t *testing.T) {
+	t.Run("any", func(t *testing.T) {
 		original := TestStruct{
-			Interface: map[string]interface{}{
+			Any: map[string]interface{}{
 				"key": "value",
 			},
 		}
@@ -94,18 +91,17 @@ func TestCopy(t *testing.T) {
 		assert.Equal(t, original, copied)
 
 		// Modify the copied interface to verify deep copy
-		copiedMap := copied.Interface.(map[string]interface{})
+		copiedMap := copied.Any.(map[string]interface{})
 		copiedMap["key"] = "new value"
-		assert.NotEqual(t, original.Interface.(map[string]interface{})["key"], "new value", "Deep() created a shallow copy of interface")
+		assert.NotEqual(t, original.Any.(map[string]interface{})["key"], "new value", "Deep() created a shallow copy of interface")
 	})
 
-	// Test case 6: Copy nil values
 	t.Run("nil values", func(t *testing.T) {
 		original := TestStruct{
-			Slice:     nil,
-			Map:       nil,
-			Ptr:       nil,
-			Interface: nil,
+			Slice: nil,
+			Map:   nil,
+			Ptr:   nil,
+			Any:   nil,
 		}
 
 		copied, err := Deep(original)
@@ -113,12 +109,11 @@ func TestCopy(t *testing.T) {
 		assert.Equal(t, original, copied)
 	})
 
-	// Test case 7: Copy empty values
 	t.Run("empty values", func(t *testing.T) {
 		original := TestStruct{
-			Slice:     []string{},
-			Map:       map[string]int{},
-			Interface: map[string]interface{}{},
+			Slice: []string{},
+			Map:   map[string]int{},
+			Any:   map[string]interface{}{},
 		}
 
 		copied, err := Deep(original)
@@ -126,7 +121,6 @@ func TestCopy(t *testing.T) {
 		assert.Equal(t, original, copied)
 	})
 
-	// Test case 8: Copy primitive type directly
 	t.Run("primitive type", func(t *testing.T) {
 		original := 42
 		copied, err := Deep(original)
@@ -134,7 +128,6 @@ func TestCopy(t *testing.T) {
 		assert.Equal(t, original, copied)
 	})
 
-	// Test case 9: Copy slice directly
 	t.Run("slice directly", func(t *testing.T) {
 		original := []string{"a", "b", "c"}
 		copied, err := Deep(original)

--- a/utils/copy/copy_test.go
+++ b/utils/copy/copy_test.go
@@ -20,7 +20,7 @@ type TestStruct struct {
 
 func TestCopy(t *testing.T) {
 
-	t.Run("primitive types", func(t *testing.T) {
+	t.Run("Successfully deep copied primitive types", func(t *testing.T) {
 		original := TestStruct{
 			String: "test",
 			Int:    42,
@@ -33,7 +33,7 @@ func TestCopy(t *testing.T) {
 		assert.Equal(t, original, copied)
 	})
 
-	t.Run("slice", func(t *testing.T) {
+	t.Run("Successfully deep copy slice types", func(t *testing.T) {
 		original := TestStruct{
 			Slice: []string{"a", "b", "c"},
 		}
@@ -47,7 +47,7 @@ func TestCopy(t *testing.T) {
 		assert.NotEqual(t, original.Slice[0], "x", "Deep() created a shallow copy of slice")
 	})
 
-	t.Run("map", func(t *testing.T) {
+	t.Run("Successfully deep copy map types", func(t *testing.T) {
 		original := TestStruct{
 			Map: map[string]int{
 				"a": 1,
@@ -64,7 +64,7 @@ func TestCopy(t *testing.T) {
 		assert.NotEqual(t, original.Map["a"], 3, "Deep() created a shallow copy of map")
 	})
 
-	t.Run("pointer", func(t *testing.T) {
+	t.Run("Successfully deep copy pointer types", func(t *testing.T) {
 		str := "test"
 		original := TestStruct{
 			Ptr: &str,
@@ -79,9 +79,9 @@ func TestCopy(t *testing.T) {
 		assert.NotEqual(t, *original.Ptr, "new", "Deep() created a shallow copy of pointer")
 	})
 
-	t.Run("any", func(t *testing.T) {
+	t.Run("Successfully copied any types", func(t *testing.T) {
 		original := TestStruct{
-			Any: map[string]interface{}{
+			Any: map[string]any{
 				"key": "value",
 			},
 		}
@@ -90,13 +90,13 @@ func TestCopy(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, original, copied)
 
-		// Modify the copied interface to verify deep copy
-		copiedMap := copied.Any.(map[string]interface{})
+		// Modify the copied any to verify deep copy
+		copiedMap := copied.Any.(map[string]any)
 		copiedMap["key"] = "new value"
-		assert.NotEqual(t, original.Any.(map[string]interface{})["key"], "new value", "Deep() created a shallow copy of interface")
+		assert.NotEqual(t, original.Any.(map[string]any)["key"], "new value", "Deep() created a shallow copy of any")
 	})
 
-	t.Run("nil values", func(t *testing.T) {
+	t.Run("Fails copied because something return nil", func(t *testing.T) {
 		original := TestStruct{
 			Slice: nil,
 			Map:   nil,
@@ -109,11 +109,11 @@ func TestCopy(t *testing.T) {
 		assert.Equal(t, original, copied)
 	})
 
-	t.Run("empty values", func(t *testing.T) {
+	t.Run("Fails copied empty values", func(t *testing.T) {
 		original := TestStruct{
 			Slice: []string{},
 			Map:   map[string]int{},
-			Any:   map[string]interface{}{},
+			Any:   map[string]any{},
 		}
 
 		copied, err := Deep(original)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -29,19 +29,19 @@ func TestToPtr(t *testing.T) {
 	t.Run("String value", func(t *testing.T) {
 		value := "test"
 		ptr := ToPtr(value)
-		assert.Equal(t, value, *ptr)
+		assert.Equal(t, "test", *ptr)
 	})
 
 	t.Run("Int value", func(t *testing.T) {
 		value := 42
 		ptr := ToPtr(value)
-		assert.Equal(t, value, *ptr)
+		assert.Equal(t, 42, *ptr)
 	})
 
 	t.Run("Bool value", func(t *testing.T) {
 		value := true
 		ptr := ToPtr(value)
-		assert.Equal(t, value, *ptr)
+		assert.Equal(t, true, *ptr)
 	})
 }
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -10,7 +10,7 @@ import (
 func TestMust(t *testing.T) {
 	tests := []struct {
 		name      string
-		obj       interface{}
+		obj       any
 		err       error
 		wantPanic bool
 	}{
@@ -48,7 +48,7 @@ func TestMust(t *testing.T) {
 func TestToPtr(t *testing.T) {
 	tests := []struct {
 		name string
-		v    interface{}
+		v    any
 	}{
 		{
 			name: "string value",
@@ -78,13 +78,13 @@ func TestJsonToMap(t *testing.T) {
 	tests := []struct {
 		name    string
 		jsonStr string
-		want    map[string]interface{}
+		want    map[string]any
 		wantErr bool
 	}{
 		{
 			name:    "valid json",
 			jsonStr: `{"key": "value", "number": 42}`,
-			want: map[string]interface{}{
+			want: map[string]any{
 				"key":    "value",
 				"number": float64(42),
 			},
@@ -95,6 +95,16 @@ func TestJsonToMap(t *testing.T) {
 			jsonStr: `{invalid json}`,
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name:    "empty json",
+			jsonStr: `{"key": "value", "number": -1, "": 2}`,
+			want: map[string]any{
+				"key":    "value",
+				"number": float64(-1),
+				"":       float64(2),
+			},
+			wantErr: false,
 		},
 	}
 
@@ -115,13 +125,13 @@ func TestJsonToMap(t *testing.T) {
 func TestMapToJson(t *testing.T) {
 	tests := []struct {
 		name    string
-		jsonMap map[string]interface{}
+		jsonMap map[string]any
 		want    string
 		wantErr bool
 	}{
 		{
-			name: "valid map",
-			jsonMap: map[string]interface{}{
+			name: "valid map to JSON",
+			jsonMap: map[string]any{
 				"key":    "value",
 				"number": 42,
 			},
@@ -129,9 +139,15 @@ func TestMapToJson(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "empty map",
-			jsonMap: map[string]interface{}{},
+			name:    "empty map to JSON",
+			jsonMap: map[string]any{},
 			want:    `{}`,
+			wantErr: false,
+		},
+		{
+			name:    "null map to JSON",
+			jsonMap: nil,
+			want:    `null`,
 			wantErr: false,
 		},
 	}
@@ -145,7 +161,7 @@ func TestMapToJson(t *testing.T) {
 			}
 			if !tt.wantErr {
 				// Compare the JSON strings after normalizing them
-				var gotMap, wantMap map[string]interface{}
+				var gotMap, wantMap any
 				json.Unmarshal([]byte(got), &gotMap)
 				json.Unmarshal([]byte(tt.want), &wantMap)
 				if !reflect.DeepEqual(gotMap, wantMap) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,157 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestMust(t *testing.T) {
+	tests := []struct {
+		name      string
+		obj       interface{}
+		err       error
+		wantPanic bool
+	}{
+		{
+			name:      "success case",
+			obj:       "test",
+			err:       nil,
+			wantPanic: false,
+		},
+		{
+			name:      "panic case",
+			obj:       nil,
+			err:       fmt.Errorf("test error"),
+			wantPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Error("Must() should have panicked but didn't")
+					}
+				}()
+			}
+			result := Must(tt.obj, tt.err)
+			if !tt.wantPanic && result != tt.obj {
+				t.Errorf("Must() = %v, want %v", result, tt.obj)
+			}
+		})
+	}
+}
+
+func TestToPtr(t *testing.T) {
+	tests := []struct {
+		name string
+		v    interface{}
+	}{
+		{
+			name: "string value",
+			v:    "test",
+		},
+		{
+			name: "int value",
+			v:    42,
+		},
+		{
+			name: "bool value",
+			v:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToPtr(tt.v)
+			if *result != tt.v {
+				t.Errorf("ToPtr() = %v, want %v", *result, tt.v)
+			}
+		})
+	}
+}
+
+func TestJsonToMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		jsonStr string
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name:    "valid json",
+			jsonStr: `{"key": "value", "number": 42}`,
+			want: map[string]interface{}{
+				"key":    "value",
+				"number": float64(42),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid json",
+			jsonStr: `{invalid json}`,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := JsonToMap(tt.jsonStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JsonToMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("JsonToMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapToJson(t *testing.T) {
+	tests := []struct {
+		name    string
+		jsonMap map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid map",
+			jsonMap: map[string]interface{}{
+				"key":    "value",
+				"number": 42,
+			},
+			want:    `{"key":"value","number":42}`,
+			wantErr: false,
+		},
+		{
+			name:    "empty map",
+			jsonMap: map[string]interface{}{},
+			want:    `{}`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MapToJson(tt.jsonMap)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MapToJson() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				// Compare the JSON strings after normalizing them
+				var gotMap, wantMap map[string]interface{}
+				json.Unmarshal([]byte(got), &gotMap)
+				json.Unmarshal([]byte(tt.want), &wantMap)
+				if !reflect.DeepEqual(gotMap, wantMap) {
+					t.Errorf("MapToJson() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -10,7 +10,6 @@ func TestMust(t *testing.T) {
 	t.Run("Return object when no error", func(t *testing.T) {
 		obj := "test"
 		err := error(nil)
-
 		got := Must(obj, err)
 		assert.Equal(t, obj, got)
 	})
@@ -18,7 +17,6 @@ func TestMust(t *testing.T) {
 	t.Run("Panic when error is not nil", func(t *testing.T) {
 		obj := any(nil)
 		err := fmt.Errorf("test error")
-
 		assert.PanicsWithValue(t, err, func() {
 			_ = Must(obj, err)
 		})
@@ -42,6 +40,18 @@ func TestToPtr(t *testing.T) {
 		value := true
 		ptr := ToPtr(value)
 		assert.Equal(t, true, *ptr)
+	})
+
+	t.Run("Float value", func(t *testing.T) {
+		value := 3.14
+		ptr := ToPtr(value)
+		assert.Equal(t, 3.14, *ptr)
+	})
+
+	t.Run("Any value", func(t *testing.T) {
+		value := []any{'a', 1, 3.14, "test", []int{1, 2, 3}}
+		ptr := ToPtr(value)
+		assert.Equal(t, []any{'a', 1, 3.14, "test", []int{1, 2, 3}}, *ptr)
 	})
 }
 


### PR DESCRIPTION
This PR increases unit test coverage for the `utils` and `copy` packages to improve reliability and correctness.  

#### **Test Coverage for `copy` Package:**  
- **Primitive types:** Ensure value equality.  
- **Pointer types:** Verify reference independence.  
- **Nested structures:** Validate deep copy behavior.  
- **Error handling:** Test cases for unsupported scenarios.  
- **Memory safety:** Ensure original and copied values remain independent.  

#### **Test Coverage for `utils` Package:**  
- **TestMust:**  
  - **Success case:** Returns the expected object.  
  - **Error case:** Panics as expected.  
- **ToPtr:** Covers both basic and complex data types.  
- **JsonToMap:** Handles valid, invalid, and empty JSON inputs.  
- **MapToJson:** Covers valid, empty, and null maps.  