### PR TITLE
Fix failing TestToOpenAiMessage due to missing union in ContentBlock

### DIFF
--- a/provider/claude/claude.go
+++ b/provider/claude/claude.go
@@ -315,7 +315,7 @@ func toClaudeToolChoice(toolChoice *openai.ToolChoice) (anthropic.ToolChoiceUnio
 				Type: anthropic.F(anthropic.ToolChoiceAnyTypeAny),
 			}, nil
 		case "none":
-			return nil, fmt.Errorf("Claude does not support 'none' tool choice")
+			return nil, fmt.Errorf("claude does not support 'none' tool choice")
 		}
 	}
 	if toolChoice.Struct == nil {
@@ -379,10 +379,10 @@ func toOpenAiMessage(claudeMessage *anthropic.Message) (*openai.Message, error) 
 	toolCalls := make([]openai.ToolCall, 0)
 
 	for _, block := range claudeMessage.Content {
-		switch block := block.AsUnion().(type) {
-		case anthropic.TextBlock:
+		switch block.Type {
+		case anthropic.ContentBlockTypeText:
 			content.WriteString(block.Text)
-		case anthropic.ToolUseBlock:
+		case anthropic.ContentBlockTypeToolUse:
 			toolCalls = append(toolCalls, openai.ToolCall{
 				Id:   block.ID,
 				Type: "function",

--- a/provider/claude/claude_test.go
+++ b/provider/claude/claude_test.go
@@ -1,0 +1,177 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/yanolja/ogem/openai"
+)
+
+func TestNewEndpoint(t *testing.T) {
+	ep, err := NewEndpoint("test-api-key")
+	assert.NoError(t, err)
+	assert.NotNil(t, ep)
+	assert.NotNil(t, ep.client)
+}
+
+func TestStandardizeModelName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"claude-3-5-sonnet", "claude-3-5-sonnet-20240620"},
+		{"claude-3-opus", "claude-3-opus-20240229"},
+		{"claude-3-sonnet", "claude-3-sonnet-20240229"},
+		{"claude-3-haiku", "claude-3-haiku-20240307"},
+		{"custom-model", "custom-model"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := standardizeModelName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToOpenAiFinishReason(t *testing.T) {
+	tests := []struct {
+		input    anthropic.MessageStopReason
+		expected string
+	}{
+		{anthropic.MessageStopReasonMaxTokens, "length"},
+		{anthropic.MessageStopReasonEndTurn, "stop"},
+		{anthropic.MessageStopReasonStopSequence, "stop"},
+		{anthropic.MessageStopReasonToolUse, "stop"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			result := toOpenAiFinishReason(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToOpenAiMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *anthropic.Message
+		expected *openai.Message
+		wantErr  bool
+	}{
+		{
+			name: "success: text block only",
+			input: &anthropic.Message{
+				Content: []anthropic.ContentBlock{
+					{
+						Type: anthropic.ContentBlockTypeText,
+						Text: "Hello, world!",
+					},
+				},
+			},
+			expected: &openai.Message{
+				Role: "assistant",
+				Content: &openai.MessageContent{
+					String: stringPtr("Hello, world!"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success: tool use block only",
+			input: &anthropic.Message{
+				Content: []anthropic.ContentBlock{
+					{
+						Type: anthropic.ContentBlockTypeToolUse,
+						ID:   "tool-123",
+						Name: "get_weather",
+						Input: []byte(`{
+							"location": "Seoul",
+							"unit": "celsius"
+						}`),
+					},
+				},
+			},
+			expected: &openai.Message{
+				Role: "assistant",
+				ToolCalls: []openai.ToolCall{
+					{
+						Id:   "tool-123",
+						Type: "function",
+						Function: &openai.FunctionCall{
+							Name: "get_weather",
+							Arguments: `{
+							"location": "Seoul",
+							"unit": "celsius"
+						}`,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success: mixed blocks",
+			input: &anthropic.Message{
+				Content: []anthropic.ContentBlock{
+					{
+						Type: anthropic.ContentBlockTypeText,
+						Text: "The weather today is: ",
+					},
+					{
+						Type: anthropic.ContentBlockTypeToolUse,
+						ID:   "tool-123",
+						Name: "get_weather",
+						Input: []byte(`{
+							"location": "Seoul",
+							"unit": "celsius"
+						}`),
+					},
+					{
+						Type: anthropic.ContentBlockTypeText,
+						Text: " Please wait for the result.",
+					},
+				},
+			},
+			expected: &openai.Message{
+				Role: "assistant",
+				Content: &openai.MessageContent{
+					String: stringPtr("The weather today is:  Please wait for the result."),
+				},
+				ToolCalls: []openai.ToolCall{
+					{
+						Id:   "tool-123",
+						Type: "function",
+						Function: &openai.FunctionCall{
+							Name: "get_weather",
+							Arguments: `{
+							"location": "Seoul",
+							"unit": "celsius"
+						}`,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := toOpenAiMessage(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper function
+func stringPtr(s string) *string {
+	return &s
+}

--- a/server/server.go
+++ b/server/server.go
@@ -342,6 +342,11 @@ func (s *ModelProxy) generateChatCompletion(ctx context.Context, openAiRequest *
 		return nil, BadRequestError{fmt.Errorf("no messages provided")}
 	}
 
+	// Determine if the response can be cached based on temperature setting.
+	// Responses are only cached when:
+	// 1. Temperature parameter is provided (not nil)
+	// 2. Temperature is effectively zero (deterministic responses)
+	// This is because non-zero temperatures introduce randomness, making caching inappropriate.
 	cacheable := openAiRequest.Temperature != nil && math.Abs(float64(*openAiRequest.Temperature)-float64(0)) < math.SmallestNonzeroFloat32
 
 	if cacheable {


### PR DESCRIPTION
### What’s fixed
Fixes #66 

The test `TestToOpenAiMessage` failed because `ContentBlock.AsUnion()` returned nil.
This PR updates the logic in `toOpenAiMessage` to handle the block's `Type` properly without relying on uninitialized `union` field.

### Changes
- Fixed union access in `toOpenAiMessage`
- Test case `toOpenAiMessage` now passes

### Notes
I added a comment for the `cacheable` to explain it as well