### PR TITLE
Added Unit Tests for provider package

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -28,14 +28,14 @@ func TestToGeminiRole(t *testing.T) {
 }
 
 func TestToGeminiResponseMimeType_SuccessCases(t *testing.T) {
-	t.Run("plain_text_nil_format", func(t *testing.T) {
+	t.Run("no format specified", func(t *testing.T) {
 		mimeType, schema, err := ToGeminiResponseMimeType(&openai.ChatCompletionRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, "text/plain", mimeType)
 		assert.Nil(t, schema)
 	})
 
-	t.Run("plain_text_format", func(t *testing.T) {
+	t.Run("plain text format", func(t *testing.T) {
 		mimeType, schema, err := ToGeminiResponseMimeType(&openai.ChatCompletionRequest{
 			ResponseFormat: &openai.ResponseFormat{
 				Type: "plain_text",
@@ -46,7 +46,7 @@ func TestToGeminiResponseMimeType_SuccessCases(t *testing.T) {
 		assert.Nil(t, schema)
 	})
 
-	t.Run("json_object", func(t *testing.T) {
+	t.Run("json object format", func(t *testing.T) {
 		mimeType, schema, err := ToGeminiResponseMimeType(&openai.ChatCompletionRequest{
 			ResponseFormat: &openai.ResponseFormat{
 				Type: "json_object",
@@ -57,7 +57,7 @@ func TestToGeminiResponseMimeType_SuccessCases(t *testing.T) {
 		assert.Nil(t, schema)
 	})
 
-	t.Run("json_schema", func(t *testing.T) {
+	t.Run("json schema format", func(t *testing.T) {
 		mimeType, schema, err := ToGeminiResponseMimeType(&openai.ChatCompletionRequest{
 			ResponseFormat: &openai.ResponseFormat{
 				Type: "json_schema",

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,0 +1,123 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yanolja/ogem/openai"
+	"github.com/yanolja/ogem/utils/orderedmap"
+)
+
+func TestToGeminiRole(t *testing.T) {
+	tests := []struct {
+		role string
+		expected string
+	}{
+		{"user", "user"},
+		{"assistant", "model"},
+		{"tool", "function"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("role: %s", test.role), func(t *testing.T) {
+			result := ToGeminiRole(test.role)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestToGeminiResponseMimeType_SuccessCases(t *testing.T) {
+	t.Run("plain_text_nil_format", func(t *testing.T) {
+		mimeType, schema, err := ToGeminiResponseMimeType(&openai.ChatCompletionRequest{})
+		assert.NoError(t, err)
+		assert.Equal(t, "text/plain", mimeType)
+		assert.Nil(t, schema)
+	})
+
+	t.Run("plain_text_format", func(t *testing.T) {
+		mimeType, schema, err := ToGeminiResponseMimeType(&openai.ChatCompletionRequest{
+			ResponseFormat: &openai.ResponseFormat{
+				Type: "plain_text",
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "text/plain", mimeType)
+		assert.Nil(t, schema)
+	})
+
+	t.Run("json_object", func(t *testing.T) {
+		mimeType, schema, err := ToGeminiResponseMimeType(&openai.ChatCompletionRequest{
+			ResponseFormat: &openai.ResponseFormat{
+				Type: "json_object",
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "application/json", mimeType)
+		assert.Nil(t, schema)
+	})
+
+	t.Run("json_schema", func(t *testing.T) {
+		mimeType, schema, err := ToGeminiResponseMimeType(&openai.ChatCompletionRequest{
+			ResponseFormat: &openai.ResponseFormat{
+				Type: "json_schema",
+				JsonSchema: &openai.JsonSchema{
+					Schema: func() *orderedmap.Map {
+						schema := orderedmap.New()
+						schema.Set("type", "object")
+						return schema
+					}(),
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "application/json", mimeType)
+		schemaType, ok := schema.Get("type")
+		assert.True(t, ok)
+		assert.Equal(t, "object", schemaType.(string))
+	})
+}
+
+func TestToGeminiResponseMimeType_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name string
+		format *openai.ChatCompletionRequest
+		expectedError string
+	}{
+		{
+			name: "missing json schema in json_schema response format",
+			format: &openai.ChatCompletionRequest{
+				ResponseFormat: &openai.ResponseFormat{
+					Type: "json_schema",
+					JsonSchema: nil,
+				},
+			},
+			expectedError: "missing json_schema in response_format",
+		},
+		{
+			name: "unsupported response format",
+			format: &openai.ChatCompletionRequest{
+				ResponseFormat: &openai.ResponseFormat{
+					Type: "unsupported",
+				},
+			},
+			expectedError: "unsupported response format: unsupported",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mimeType, schema, err := ToGeminiResponseMimeType(test.format)
+			assert.Error(t, err)
+			assert.Equal(t, test.expectedError, err.Error())
+			assert.Equal(t, "", mimeType)
+			assert.Nil(t, schema)
+		})
+	}
+}
+
+func createJsonSchema() *orderedmap.Map {
+	schema := orderedmap.New()
+	schema.Set("type", "object")
+	return schema
+}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -115,9 +115,3 @@ func TestToGeminiResponseMimeType_ErrorCases(t *testing.T) {
 		})
 	}
 }
-
-func createJsonSchema() *orderedmap.Map {
-	schema := orderedmap.New()
-	schema.Set("type", "object")
-	return schema
-}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -58,15 +58,13 @@ func TestToGeminiResponseMimeType_SuccessCases(t *testing.T) {
 	})
 
 	t.Run("json schema format", func(t *testing.T) {
+		schema := orderedmap.New()
+		schema.Set("type", "object")
 		mimeType, schema, err := ToGeminiResponseMimeType(&openai.ChatCompletionRequest{
 			ResponseFormat: &openai.ResponseFormat{
 				Type: "json_schema",
 				JsonSchema: &openai.JsonSchema{
-					Schema: func() *orderedmap.Map {
-						schema := orderedmap.New()
-						schema.Set("type", "object")
-						return schema
-					}(),
+					Schema: schema,
 				},
 			},
 		})


### PR DESCRIPTION
## Summary
This PR adds unit tests to improve the test coverage for the following functions in the `provider` package:

- `ToGeminiRole(role string) string`
- `ToGeminiResponseMimeType(req *openai.ChatCompletionRequest) (string, *orderedmap.Map, error)`

## Details

### `ToGeminiRole` tests
- Verifies correct mapping of roles from OpenAI (`user`, `assistant`, `tool`) to Gemini-compatible roles (`user`, `model`, `function`).

### `ToGeminiResponseMimeType` tests

#### Success cases:
- Handles non-specified, plain text, json object, and json schema response formats.

#### Error cases:
- Detects missing schema in `json_schema` format.
- Handles unsupported response formats with appropriate error messages.

## Test Coverage
- All logical branches of both functions are now covered.