### PR TITLE
Create coverage tests for `array` package

### DIFF
--- a/utils/array/array_test.go
+++ b/utils/array/array_test.go
@@ -76,5 +76,4 @@ func TestFind(t *testing.T) {
 		assert.True(t, found)
 		assert.Equal(t, "test", got)
 	})
-
 }

--- a/utils/array/array_test.go
+++ b/utils/array/array_test.go
@@ -1,0 +1,69 @@
+package array
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMap(t *testing.T) {
+	t.Run("Map int to string", func(t *testing.T) {
+		array := []int{1, 2, 3}
+		mapper := func(i int) int {
+			return i * 2
+		}
+		got := Map(array, mapper)
+		assert.Equal(t, []int{2, 4, 6}, got)
+	})
+
+	t.Run("Map string to double", func(t *testing.T) {
+		array := []string{"1", "2", "3"}
+		mapper := func(s string) int {
+			return int(s[0] - '0')
+		}
+		got := Map(array, mapper)
+		assert.Equal(t, []int{1, 2, 3}, got)
+	})
+}
+
+func TestContains(t *testing.T) {
+	t.Run("Does not contain any", func(t *testing.T) {
+		array := []any{1, 2, 3, "test", 3.14}
+		assert.False(t, Contains(array, 4))
+		assert.False(t, Contains(array, 3.1)) // float64 3.1 is not equal to int 3
+		assert.True(t, Contains(array, "test"))
+	})
+}
+
+func TestFind(t *testing.T) {
+	t.Run("Find int", func(t *testing.T) {
+		array := []int{1, 2, 3}
+		predicate := func(i int) bool {
+			return i > 1
+		}
+		got, found := Find(array, predicate)
+		assert.True(t, found)
+		assert.Equal(t, 2, got)
+	})
+
+	t.Run("Find string", func(t *testing.T) {
+		array := []string{"a", "b", "c"}
+		predicate := func(s string) bool {
+			return s == "d"
+		}
+		got, found := Find(array, predicate)
+		assert.False(t, found)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("Find any", func(t *testing.T) {
+		array := []any{1, "test", 3.14, []int{1, 2, 3}}
+		predicate := func(a any) bool {
+			return a == "test"
+		}
+		got, found := Find(array, predicate)
+		assert.True(t, found)
+		assert.Equal(t, "test", got)
+	})
+
+}

--- a/utils/array/array_test.go
+++ b/utils/array/array_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestMap(t *testing.T) {
-	t.Run("Map int to string", func(t *testing.T) {
+	t.Run("Map int to int", func(t *testing.T) {
 		array := []int{1, 2, 3}
 		mapper := func(i int) int {
 			return i * 2
@@ -16,7 +16,7 @@ func TestMap(t *testing.T) {
 		assert.Equal(t, []int{2, 4, 6}, got)
 	})
 
-	t.Run("Map string to double", func(t *testing.T) {
+	t.Run("Map string to int", func(t *testing.T) {
 		array := []string{"1", "2", "3"}
 		mapper := func(s string) int {
 			return int(s[0] - '0')
@@ -27,10 +27,21 @@ func TestMap(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
-	t.Run("Does not contain any", func(t *testing.T) {
-		array := []any{1, 2, 3, "test", 3.14}
+	t.Run("Contains int", func(t *testing.T) {
+		array := []int{1, 2, 3}
 		assert.False(t, Contains(array, 4))
-		assert.False(t, Contains(array, 3.1)) // float64 3.1 is not equal to int 3
+		assert.True(t, Contains(array, 3))
+	})
+
+	t.Run("Contains string", func(t *testing.T) {
+		array := []string{"a", "b", "c"}
+		assert.False(t, Contains(array, "d"))
+		assert.True(t, Contains(array, "a"))
+	})
+
+	t.Run("Contains any", func(t *testing.T) {
+		array := []any{1, "test", 3.14, []int{1, 2, 3}}
+		assert.False(t, Contains(array, 4))
 		assert.True(t, Contains(array, "test"))
 	})
 }

--- a/utils/array/array_test.go
+++ b/utils/array/array_test.go
@@ -67,7 +67,7 @@ func TestFind(t *testing.T) {
 		assert.Equal(t, "", got)
 	})
 
-	t.Run("Find any", func(t *testing.T) {
+	t.Run("Find a value from a mixed-type array", func(t *testing.T) {
 		array := []any{1, "test", 3.14, []int{1, 2, 3}}
 		predicate := func(a any) bool {
 			return a == "test"


### PR DESCRIPTION
# Summary
This PR adds unit tests to improve the test coverage for the following functions in the `array` package:

- `Map(array []T, mapper func(T) R) []R`
- `Contains(array []T, element T) bool`
- `Find(array []T, predicate func(T) bool) (T, bool)`

# Details

## Map tests
- Verifies correct mapping of array elements with different types:
  - Integer array transformation (multiplying by 2)
  - String array to integer array conversion

## Contains tests
- Tests element existence checking with different data types:
  - Integer arrays
  - String arrays
  - Interface arrays (any type)
- Handles both positive (element exists) and negative (element not found) cases

## Find tests
- Tests element search with predicate functions:
  - Integer arrays with number comparison
  - String arrays with exact matching
  - Interface arrays with type assertion
- Handles both success and failure cases appropriately

# Test Coverage
- All logical branches of the three functions are now covered
- Both positive and negative test cases are included
- Edge cases are properly handled