### PR TITLE
Add OpenAI Create Embeddings endpoint

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -141,7 +141,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/chat/completions", proxy.HandleAuthentication(proxy.HandleChatCompletions))
-
+	mux.HandleFunc("/v1/embeddings", proxy.HandleAuthentication(proxy.HandleEmbeddings))
 	corsMiddleware := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
 		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},

--- a/config.yaml
+++ b/config.yaml
@@ -125,6 +125,18 @@ providers:
             rate_key: "gpt-3.5-turbo@batch"
             rpm: 1_000_000
             tpm: 5_000_000_000
+          - name: "text-embedding-ada-002"
+            rate_key: "text-embedding-ada-002"
+            rpm: 1_000_000
+            tpm: 150_000_000
+          - name: "text-embedding-3-small"
+            rate_key: "text-embedding-3-small"
+            rpm: 1_000_000
+            tpm: 150_000_000
+          - name: "text-embedding-3-large"
+            rate_key: "text-embedding-3-large"
+            rpm: 1_000_000
+            tpm: 150_000_000
   vertex:
     regions:
       default:

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -320,3 +320,31 @@ func FinalizeResponse(provider string, region string, model string, response *Ch
 	response.Object = "chat.completion"
 	return response
 }
+
+type EmbeddingRequest struct {
+	Input          any    `json:"input"` // Could be: string, []string, []int, [][]int
+	Model          string `json:"model"`
+	User           string `json:"user,omitempty"`
+	Dimensions     int32  `json:"dimensions,omitempty"`      // Only supported in "text-embedding-3" and later models
+	EncodingFormat string `json:"encoding_format,omitempty"` // Should be "float" or "base64"
+}
+
+type EmbeddingResponse struct {
+	Embedding []float32      `json:"embedding"`
+	Index     int32          `json:"index"`
+	Object    string         `json:"object"`
+	Data      []Data         `json:"data"`
+	Model     string         `json:"model"`
+	Usage     EmbeddingUsage `json:"usage"`
+}
+
+type Data struct {
+	Index     int32     `json:"index"`
+	Object    string    `json:"object"`
+	Embedding []float32 `json:"embedding"`
+}
+
+type EmbeddingUsage struct {
+	PromptTokens int32 `json:"prompt_tokens"`
+	TotalTokens  int32 `json:"total_tokens"`
+}

--- a/provider/claude/claude.go
+++ b/provider/claude/claude.go
@@ -436,5 +436,5 @@ func standardizeModelName(model string) string {
 }
 
 func (ep *Endpoint) CreateEmbeddings(ctx context.Context, request *openai.EmbeddingRequest) (*openai.EmbeddingResponse, error) {
-	return nil, fmt.Errorf("Currently, Claude does not support embeddings") // TODO: Implement Claude embeddings
+	return nil, fmt.Errorf("Currently, Claude does not support embeddings") // TODO(#101): Implement Claude embeddings
 }

--- a/provider/claude/claude.go
+++ b/provider/claude/claude.go
@@ -434,3 +434,7 @@ func standardizeModelName(model string) string {
 	}
 	return model
 }
+
+func (ep *Endpoint) CreateEmbeddings(ctx context.Context, request *openai.EmbeddingRequest) (*openai.EmbeddingResponse, error) {
+	return nil, fmt.Errorf("Currently, Claude does not support embeddings") // TODO: Implement Claude embeddings
+}

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -579,8 +579,6 @@ func (p *Endpoint) CreateEmbeddings(ctx context.Context, request *openai.Embeddi
 	httpRequest.Header.Set("Content-Type", "application/json")
 	httpRequest.Header.Set("Authorization", "Bearer "+p.apiKey)
 
-	log.Printf("Sending %s request to %s with body: %s", httpRequest.Method, endpointPath, string(jsonData))
-
 	httpResponse, err := p.client.Do(httpRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %v", err)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -12,6 +12,7 @@ import (
 
 type AiEndpoint interface {
 	GenerateChatCompletion(ctx context.Context, request *openai.ChatCompletionRequest) (*openai.ChatCompletionResponse, error)
+	CreateEmbeddings(ctx context.Context, request *openai.EmbeddingRequest) (*openai.EmbeddingResponse, error)
 	Ping(ctx context.Context) (time.Duration, error)
 	Provider() string
 	Region() string

--- a/provider/studio/studio.go
+++ b/provider/studio/studio.go
@@ -638,5 +638,5 @@ func toOpenAiFinishReason(finishReason genai.FinishReason) string {
 }
 
 func (ep *Endpoint) CreateEmbeddings(ctx context.Context, request *openai.EmbeddingRequest) (*openai.EmbeddingResponse, error) {
-	return nil, fmt.Errorf("Currently, Studio does not support embeddings") // TODO: Implement Gemini embeddings
+	return nil, fmt.Errorf("Currently, Studio does not support embeddings") // TODO(#102): Implement Gemini embeddings
 }

--- a/provider/studio/studio.go
+++ b/provider/studio/studio.go
@@ -636,3 +636,7 @@ func toOpenAiFinishReason(finishReason genai.FinishReason) string {
 		return "content_filter"
 	}
 }
+
+func (ep *Endpoint) CreateEmbeddings(ctx context.Context, request *openai.EmbeddingRequest) (*openai.EmbeddingResponse, error) {
+	return nil, fmt.Errorf("Currently, Studio does not support embeddings") // TODO: Implement Gemini embeddings
+}

--- a/provider/vclaude/vclaude.go
+++ b/provider/vclaude/vclaude.go
@@ -434,3 +434,7 @@ func standardizeModelName(model string) string {
 	}
 	return model
 }
+
+func (ep *Endpoint) CreateEmbeddings(ctx context.Context, request *openai.EmbeddingRequest) (*openai.EmbeddingResponse, error) {
+	return nil, fmt.Errorf("Currently, VClaude does not support embeddings") // TODO: Implement VClaude embeddings
+}

--- a/provider/vclaude/vclaude.go
+++ b/provider/vclaude/vclaude.go
@@ -436,5 +436,5 @@ func standardizeModelName(model string) string {
 }
 
 func (ep *Endpoint) CreateEmbeddings(ctx context.Context, request *openai.EmbeddingRequest) (*openai.EmbeddingResponse, error) {
-	return nil, fmt.Errorf("Currently, VClaude does not support embeddings") // TODO: Implement VClaude embeddings
+	return nil, fmt.Errorf("Currently, VClaude does not support embeddings") // TODO(#103): Implement VClaude embeddings
 }

--- a/provider/vertex/vertex.go
+++ b/provider/vertex/vertex.go
@@ -635,3 +635,7 @@ func toOpenAiFinishReason(finishReason genai.FinishReason) string {
 		return "content_filter"
 	}
 }
+
+func (ep *Endpoint) CreateEmbeddings(ctx context.Context, request *openai.EmbeddingRequest) (*openai.EmbeddingResponse, error) {
+	return nil, fmt.Errorf("Currently, Vertex does not support embeddings") // TODO: Implement Vertex embeddings
+}

--- a/provider/vertex/vertex.go
+++ b/provider/vertex/vertex.go
@@ -637,5 +637,5 @@ func toOpenAiFinishReason(finishReason genai.FinishReason) string {
 }
 
 func (ep *Endpoint) CreateEmbeddings(ctx context.Context, request *openai.EmbeddingRequest) (*openai.EmbeddingResponse, error) {
-	return nil, fmt.Errorf("Currently, Vertex does not support embeddings") // TODO: Implement Vertex embeddings
+	return nil, fmt.Errorf("Currently, Vertex does not support embeddings") // TODO(#104): Implement Vertex embeddings
 }


### PR DESCRIPTION
This PR introduces the `CreateEmbeddings` function to interact with OpenAI’s embeddings API. The function sends a POST request to the `/embeddings` endpoint with the required payload and returns the generated embeddings response.
Additionally, to maintain compatibility with the AiEndpoint interface, placeholder functions have been added for providers that do not yet support embeddings (i.e., Claude, Studio, VClaude, Vertex). These functions return an error message indicating that embeddings are not currently supported, with TODOs for future implementation.

### Changes:
- Implement CreateEmbeddings method to handle requests to OpenAI’s embedding API.
- Serialize EmbeddingRequest to JSON and send it in the request body.
- Handle API responses, including error handling for non-200 status codes.
- Add logging for outgoing requests.
- Add placeholder CreateEmbeddings methods for Claude and Studio providers to prevent interface errors.

### Next Steps:

- Add unit tests for CreateEmbeddings using a mock HTTP client.
- Extend error handling to provide more granular error messages.
- Implement embeddings support for Claude, Studio, VClaude, and Vertex when available.
